### PR TITLE
fix clear_buffer + clear region + bugfixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no-std", "st7920", "lcd", "embedded", "embedded-hal-driver"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/wjakobczyk/st7920"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2018"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,10 +302,13 @@ where
             adj_x = WIDTH as u8 - (x + w);
         }
 
-        let left = (adj_x / X_ADDR_DIV) * X_ADDR_DIV;
-        let mut right = ((adj_x + w) / X_ADDR_DIV) * X_ADDR_DIV;
-        if right < adj_x + w {
-            right += X_ADDR_DIV; //make sure rightmost pixels are covered
+        let mut left = adj_x - adj_x % X_ADDR_DIV;
+        let mut right = (adj_x + w) - 1;
+        right -= right % X_ADDR_DIV;
+        right += X_ADDR_DIV;
+
+        if left > adj_x {
+            left -= X_ADDR_DIV; //make sure rightmost pixels are covered
         }
 
         let mut row_start = y as usize * ROW_SIZE;
@@ -341,15 +344,9 @@ where
     CS: OutputPin<Error = PinError>,
 {
     fn size(&self) -> Size {
-        match self.flip {
-            false => Size {
-                width: WIDTH,
-                height: HEIGHT,
-            },
-            true => Size {
-                width: HEIGHT,
-                height: WIDTH,
-            },
+        Size {
+            width: WIDTH,
+            height: HEIGHT,
         }
     }
 }
@@ -383,6 +380,7 @@ where
     }
 }
 
+#[cfg(feature = "graphics")]
 impl<SPI, RST, CS, PinError, SPIError> ST7920<SPI, RST, CS>
 where
     SPI: spi::Write<u8, Error = SPIError>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ where
     fn enable_cs(&mut self, delay: &mut dyn DelayUs<u32>) -> Result<(), Error<SPIError, PinError>> {
         if let Some(cs) = self.cs.as_mut() {
             cs.set_high().map_err(Error::Pin)?;
-            delay.delay_us(2);
+            delay.delay_us(1);
         }
         Ok(())
     }
@@ -178,6 +178,17 @@ where
         Ok(())
     }
 
+    /// .
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use st7920::ST7920;
+    ///
+    /// let mut st7920 = ;
+    /// st7920.modify_buffer(f);
+    /// assert_eq!(st7920, );
+    /// ```
     pub fn modify_buffer(&mut self, f: fn(x: u8, y: u8, v: u8) -> u8) {
         for i in 0..BUFFER_SIZE {
             let row = i / ROW_SIZE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,8 +191,13 @@ where
             self.buffer[i] = 0;
         }
     }
+
     /// Clear whole display area
     pub fn clear(&mut self, delay: &mut dyn DelayUs<u32>) -> Result<(), Error<SPIError, PinError>> {
+        self.clear_buffer();
+        self.flush(delay)?;
+        Ok(())
+    }
         self.enable_cs(delay)?;
 
         for y in 0..HEIGHT as u8 / 2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,19 @@ where
         Ok(())
     }
 
+    pub fn modify_buffer(&mut self, f: fn(x: u8, y: u8, v: u8) -> u8) {
+        for i in 0..BUFFER_SIZE {
+            let row = i / ROW_SIZE;
+            let column = i - (row * ROW_SIZE);
+            self.buffer[i] = f(column as u8, row as u8, self.buffer[i]);
+        }
+    }
+
+    pub fn clear_buffer(&mut self) {
+        for i in 0..BUFFER_SIZE {
+            self.buffer[i] = 0;
+        }
+    }
     /// Clear whole display area
     pub fn clear(&mut self, delay: &mut dyn DelayUs<u32>) -> Result<(), Error<SPIError, PinError>> {
         self.enable_cs(delay)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ where
         let end_gap = 8 - (right % 8);
 
         let mut row_start = y as usize * ROW_SIZE;
-        for y in y..y + h {
+        for _ in y..y + h {
             let start = left / 8 + 1;
             let end = right / 8;
 
@@ -309,18 +309,17 @@ where
         }
 
         let mut row_start = y as usize * ROW_SIZE;
+        self.set_address(adj_x, y)?;
         for y in y..(y + h) {
             self.set_address(adj_x, y)?;
 
             for x in left / 8..right / 8 {
                 self.write_data(self.buffer[row_start + x as usize])?;
-                //TODO send in a single SPI transaction
             }
 
             row_start += ROW_SIZE;
         }
 
-        self.set_address(0, 0)?;
         self.disable_cs(delay)?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,10 +294,7 @@ use embedded_graphics;
 
 #[cfg(feature = "graphics")]
 use embedded_graphics::{
-    prelude::*,
-    geometry::Point,
-    pixelcolor::BinaryColor,
-    draw_target::DrawTarget,
+    draw_target::DrawTarget, geometry::Point, pixelcolor::BinaryColor, prelude::*,
 };
 
 #[cfg(feature = "graphics")]
@@ -309,8 +306,14 @@ where
 {
     fn size(&self) -> Size {
         match self.flip {
-            false => Size { width: WIDTH, height: HEIGHT },
-            true => Size { width: HEIGHT, height: WIDTH },
+            false => Size {
+                width: WIDTH,
+                height: HEIGHT,
+            },
+            true => Size {
+                width: HEIGHT,
+                height: WIDTH,
+            },
         }
     }
 }
@@ -327,20 +330,22 @@ where
 
     fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
     where
-        I: IntoIterator<Item = Pixel<Self::Color>>
+        I: IntoIterator<Item = Pixel<Self::Color>>,
     {
         for p in pixels {
             let Pixel(coord, color) = p;
             let x = coord.x as u8;
             let y = coord.y as u8;
-            let c = match color { BinaryColor::Off => 0 , BinaryColor::On => 1 };
+            let c = match color {
+                BinaryColor::Off => 0,
+                BinaryColor::On => 1,
+            };
             self.set_pixel(x, y, c);
         }
 
         Ok(())
     }
 }
-
 
 impl<SPI, RST, CS, PinError, SPIError> ST7920<SPI, RST, CS>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,26 +216,25 @@ where
             adj_x = WIDTH as u8 - (x + w);
         }
 
-        let left = (adj_x / X_ADDR_DIV) * X_ADDR_DIV;
+        let start = adj_x / 8;
+        let mut right = adj_x + w;
+        let end = (right / 8) + 1;
+
         let start_gap = adj_x % 8;
-        let mut right = ((adj_x + w) / X_ADDR_DIV) * X_ADDR_DIV;
-        if right < adj_x + w {
-            right += X_ADDR_DIV; //make sure rightmost pixels are covered
-        }
+
+        right = end * 8;
+
         let end_gap = 8 - (right % 8);
 
         let mut row_start = y as usize * ROW_SIZE;
         for _ in y..y + h {
-            let start = left / 8 + 1;
-            let end = right / 8;
-
             for x in start..end {
                 let mut mask = 0xFF_u8;
                 if x == start {
                     mask = 0xFF_u8 >> start_gap;
                 }
                 if x == end {
-                    mask = mask & (0xFF_u8 << end_gap);
+                    mask &= 0xFF_u8 >> end_gap;
                 }
 
                 let pos = row_start + x as usize;


### PR DESCRIPTION
Hi,

I only want to add the `fn clear_buffer_region()`. During this, I found a couple of things that are not working perfectly. 

I think some people do not use this crate in all its capabilities. Therefore it would not appear to them immediately. But, As soon as you try to optimize the performance with `fn flash_region()`, you will face the same issues that made me do this fix.  :smile: 

### Changes

- fix flush_region: no longer flushing the screen first line (y=0) above the region. 
- fix flush_region: only flashed the correct region now.
- fix dimensions:  flip is not rotation
- lint file
- add `clear_buffer` to clear the buffer (not in clear to enable double-buffering)
- add `modify_buffer` to modify the buffer manually (somehow in a safe manner)
- add `clear_buffer_region` to clear a specific region of the buffer
- add `#[cfg(feature = "graphics")]` to `flush_region_graphics` to be more consistent

### Version bump

 Version 0.3 because of:
 
- new behavior of `clear()`. (clears buffer and use flush)
- flush_region_graphics in `#[cfg(feature = "graphics")]`

It is tested a lot in my current project. (but it is always good to run some tests on your own :smiley:)

### Missing task

It is still not safe to write to regions outside of the buffer. I didn't find decent behavior to make all users happy. :disappointed:

Cheers :beers: 