### PR TITLE
Off screen drawing: Implement limit checks to avoid panicing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ lto = true
 [features]
 default = ["graphics"]
 graphics = ["embedded-graphics"]
+graphics-unchecked = ["graphics"]


### PR DESCRIPTION
Going (slightly) out of bounds with the abstract operations of `embedded_graphics` is extremely easy and often hard or even impossible to avoid. Consider a graphics object that is only partially on screen.

`st7920` panics in such a situation, which is less than optimal.

Fix this by making (partial) off screen draws a no-op and avoid panics.
Also avoid integer over- and underruns, which resulted in out of bounds panics, too.