### PR TITLE
Fix: ChipSelect is never deselected

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["no-std", "st7920", "lcd", "embedded", "embedded-hal-driver"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/wjakobczyk/st7920"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 
 [dependencies]

--- a/example_esp32/src/main.rs
+++ b/example_esp32/src/main.rs
@@ -40,8 +40,8 @@ fn main() {
     let mut delay = hal::delay::Ets;
     let mut disp = ST7920::new(
         spi_dev_drv,
-        hal::gpio::PinDriver::output(dp.pins.gpio5).unwrap(),
-        Some(hal::gpio::PinDriver::output(dp.pins.gpio4).unwrap()),
+        hal::gpio::PinDriver::output(dp.pins.gpio33).unwrap(),
+        Some(hal::gpio::PinDriver::output(dp.pins.gpio15).unwrap()),
         false,
     );
     disp.init(&mut delay).expect("could not init display");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ where
     ) -> Result<(), Error<SPIError, PinError>> {
         if let Some(cs) = self.cs.as_mut() {
             delay.delay_us(1);
-            cs.set_high().map_err(Error::Pin)?;
+            cs.set_low().map_err(Error::Pin)?;
         }
         Ok(())
     }


### PR DESCRIPTION
The function disable_cs() is wrong. It sets the CS pin to high (just like enable_cs()), which is wrong.
Change it to low.

This PR also changes all error paths during CS-enabled-sections to always go through disable_cs() so that the CS is not stuck enabled on errors.
This is done by moving the actual logic to do_...() functions. (Logic unchanged).
Then disable_cs() is always called and the do-error is returned.